### PR TITLE
Deploy scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-export ETH_FROM="YOUR_DEFAULT_SENDER_ACCOUNT"
-export ETH_RPC_URL="https://sepolia.infura.io/v3/INFURA_API_KEY"
-export PRIVATE_KEY="YOUR_PRIVATE_KEY"
+GOERLI_RPC_URL=https://goerli.infura.io/v3/KEY_HERE
+PRIVATE_KEY=
+ETHERSCAN_API_KEY=

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,22 @@
+## Deploy
+
+### Tenderizer Factory
+
+The Tenderizer Factory and all associated components need to be deployed only once per network by setting the vars in
+`.env` and running:
+
+```
+source env
+forge script deploy/1_Tenderizer.s.sol --broadcast --rpc-url $GOERLI_RPC_URL --verify
+```
+
+### Adpaters
+
+We can deploy adapters for each integration on the network using:
+
+```
+forge script deploy/2_Adapter.s.sol --broadcast --rpc-url $GOERLI_RPC_URL --verify --sig "run(address,string,address)" <REGISTRY>
+<NAME{Graph,Livepeer}> <UNDERYLING_TOKEN>
+```
+
+Note: when a new adapter is added, the deploy script has to be modified to include the new adapter.

--- a/deploy/1_Tenderizer.s.sol
+++ b/deploy/1_Tenderizer.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+//
+//  _____              _           _
+// |_   _|            | |         (_)
+//   | | ___ _ __   __| | ___ _ __ _ _______
+//   | |/ _ \ '_ \ / _` |/ _ \ '__| |_  / _ \
+//   | |  __/ | | | (_| |  __/ |  | |/ /  __/
+//   \_/\___|_| |_|\__,_|\___|_|  |_/___\___|
+//
+// Copyright (c) Tenderize Labs Ltd
+
+/*
+Run:
+source env
+forge script deploy/1_Tenderizer.s.sol --broadcast --rpc-url $GOERLI_RPC_URL --verify
+*/
+
+pragma solidity 0.8.17;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+
+import { ERC1967Proxy } from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import "core/factory/Factory.sol";
+import "core/registry/Registry.sol";
+import "core/tenderizer/Tenderizer.sol";
+import "core/unlocks/Renderer.sol";
+import "core/unlocks/Unlocks.sol";
+
+contract Deploy is Script {
+    bytes32 private constant FACTORY_ROLE = keccak256("FACTORY_ROLE");
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        Registry registryImpl = new Registry();
+        bytes memory data = abi.encodeWithSignature("initialize()");
+        Registry registry = Registry(address(new ERC1967Proxy(address(registryImpl), data)));
+
+        address rendererImpl = address(new Renderer());
+        address renderer = address(new ERC1967Proxy(rendererImpl, abi.encodeWithSignature("initialize()")));
+        address unlocks = address(new Unlocks(address(registry), renderer));
+
+        address tenderizerImpl = address(new Tenderizer());
+        address factory = address(new Factory(address(registry), tenderizerImpl, unlocks));
+        registry.grantRole(FACTORY_ROLE, address(factory));
+
+        // TODO: Swap
+
+        vm.stopBroadcast();
+
+        console2.log("Registry Proxy: %s", address(registry));
+        console2.log("Registry Impl: %s", address(registryImpl));
+        console2.log("---------------------");
+        console2.log("Tenderizer Impl: %s", address(tenderizerImpl));
+        console2.log("Renderer Impl: %s", address(rendererImpl));
+        console2.log("Renderer Proxy: %s", address(renderer));
+        console2.log("Unlocks: %s", address(unlocks));
+        console2.log("Tenderizer Factory created and registered at: %s", address(factory));
+    }
+}

--- a/deploy/2_Adapter.s.sol
+++ b/deploy/2_Adapter.s.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+//
+//  _____              _           _
+// |_   _|            | |         (_)
+//   | | ___ _ __   __| | ___ _ __ _ _______
+//   | |/ _ \ '_ \ / _` |/ _ \ '__| |_  / _ \
+//   | |  __/ | | | (_| |  __/ |  | |/ /  __/
+//   \_/\___|_| |_|\__,_|\___|_|  |_/___\___|
+//
+// Copyright (c) Tenderize Labs Ltd
+
+/*
+source env
+forge script deploy/2_Adapter.s.sol --broadcast --rpc-url $GOERLI_RPC_URL --verify --sig "run(address,string,address)" <REGISTRY>
+<NAME{Graph,Livepeer}> <LPT_TOKEN>
+*/
+
+pragma solidity 0.8.17;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+
+import { ERC1967Proxy } from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import "core/adapters/LivepeerAdapter.sol";
+import "core/adapters/GraphAdapter.sol";
+import "core/registry/Registry.sol";
+
+contract DeployAdapter is Script {
+    function run(Registry registry, string memory name, address asset) external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        address adapter;
+        if (stringsEq(name, "Graph")) {
+            adapter = address(new GraphAdapter());
+        } else if (stringsEq(name, "Livepeer")) {
+            adapter = address(new LivepeerAdapter());
+        } else {
+            revert("Invalid adapter name");
+        }
+
+        registry.registerAdapter(asset, adapter);
+        vm.stopBroadcast();
+
+        console2.log("Adapter deployed and registered: %s", adapter);
+    }
+
+    function stringsEq(string memory str1, string memory str2) public pure returns (bool) {
+        return keccak256(abi.encodePacked(str1)) == keccak256(abi.encodePacked(str2));
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,11 +1,12 @@
 # Full reference https://github.com/foundry-rs/foundry/tree/master/config
 
 [profile.default]
+script = "deploy"
 bytecode_hash = "none"
 fuzz = { runs = 1_000 }
 gas_reports = ["*"]
 libs = ["lib"]
-# optimizer = true (default)
+optimizer = true
 optimizer_runs = 200
 fs_permissions = [{ access = "read-write", path = "./" }]
 solc = "0.8.17"
@@ -28,3 +29,9 @@ wrap_comments = true
 fail_on_revert = false
 runs = 256
 depth = 100
+
+[rpc_endpoints]
+goerli = "${GOERLI_RPC_URL}"
+
+[etherscan]
+goerli = { key = "${ETHERSCAN_API_KEY}" }

--- a/test/tenderizer/Tenderizer.t.sol
+++ b/test/tenderizer/Tenderizer.t.sol
@@ -47,10 +47,14 @@ contract TenderizerSetup is Test, TestHelpers {
 
     bytes internal constant ERROR_MESSAGE = "ADAPTER_CALL_FAILED";
 
+    string internal symbol = "FOO";
+
     function setUp() public {
         // Setup global mock responses
         vm.mockCall(router, abi.encodeCall(Registry.adapter, (asset)), abi.encode(adapter));
+        vm.mockCall(router, abi.encodeCall(Registry.fee, (asset)), abi.encode(0.05 ether));
         vm.mockCall(router, abi.encodeCall(Registry.treasury, ()), abi.encode(treasury));
+        vm.mockCall(asset, abi.encodeCall(IERC20Metadata.symbol, ()), abi.encode(symbol));
 
         tenderizer = TenderizerHarness(address(new TenderizerHarness()).clone(abi.encodePacked(asset, validator, router, unlocks)));
     }
@@ -58,13 +62,12 @@ contract TenderizerSetup is Test, TestHelpers {
 
 // solhint-disable func-name-mixedcase
 contract TenderizerTest is TenderizerSetup, TenderizerEvents {
-    function test_Metadata() public {
-        string memory symbol = "FOO";
-        vm.mockCall(asset, abi.encodeCall(IERC20Metadata.symbol, ()), abi.encode(symbol));
-
+    function test_Name() public {
         vm.expectCall(asset, abi.encodeCall(IERC20Metadata.symbol, ()));
         assertEq(tenderizer.name(), string(abi.encodePacked("tender", symbol, " ", validator)), "invalid name");
+    }
 
+    function test_Symbol() public {
         vm.expectCall(asset, abi.encodeCall(IERC20Metadata.symbol, ()));
         assertEq(tenderizer.symbol(), string(abi.encodePacked("t", symbol, "_", validator)), "invalid symbol");
     }


### PR DESCRIPTION
- Deployment addresses here are only saved in the `broadcasts` and are printed out by the scripts.
- Single script for deploying everything on a network except for the adapters: `1_Tenderizer.s.sol`.
- Adapters can be deployed using `2_Adapters.s.sol`, the script needs slight modifications when new Adapters are added to the repository.

Closes #38 