### PR TITLE
[THE GRAPH] fix: unlockTime should return THAWING_PERIOD times two

### DIFF
--- a/src/adapters/GraphAdapter.sol
+++ b/src/adapters/GraphAdapter.sol
@@ -98,7 +98,7 @@ contract GraphAdapter is Adapter {
     }
 
     function unlockTime() external view override returns (uint256) {
-        return GRAPH_STAKING.thawingPeriod();
+        return GRAPH_STAKING.thawingPeriod() * 2;
     }
 
     function currentTime() external view override returns (uint256) {


### PR DESCRIPTION
`Unlocks::getMetadata` is a view only function intended to mainly be used by the `Renderer` contract to render the returned metadata as an SVG for display on NFT marketplaces like OpenSea. 

```solidity 
    /**
     * @notice Returns the metadata of an unlock token
     * @param tokenId ID of the unlock token
     * @return metadata of the unlock token
     */
    function getMetadata(uint256 tokenId) external view returns (Metadata memory metadata) {
        (address payable tenderizer, uint96 unlockId) = _decodeTokenId(tokenId);
        address asset = Tenderizer(tenderizer).asset();

        Adapter adapter = Tenderizer(tenderizer).adapter();
        uint256 maturity = Tenderizer(tenderizer).unlockMaturity(unlockId);
        uint256 currentTime = adapter.currentTime();

        return Metadata({
            amount: Tenderizer(tenderizer).previewWithdraw(unlockId),
            maturity: maturity,
            **progress: maturity > currentTime
                ? 100 - FixedPointMathLib.mulDivUp((maturity - currentTime), 100, adapter.unlockTime())
                : 100,**
            unlockId: unlockId,
            symbol: ERC20(asset).symbol(),
            name: ERC20(asset).name(),
            validator: Tenderizer(tenderizer).validator()
        });
    }
    ```

The problem exists in `Metadata::progress` , in case of **The Graph (and only The Graph)** his function would currently revert if the *unlock time* for a specific `unlockID` is GREATER THAN `THAWING_PERIOD`

Remember for The Graph, we have to batch up user unlocks and process them on a rolling window of each `THAWING_PERIOD`

This means that worst case scenario, the unlock time for a user can be `THAWING_PERIOD * 2`. 

However `GraphAdater::unlockTIme` returns `THAWING_PERIOD`

Meaning that the following line in our `Unlocks::getMetadata` can revert if `maturity - currentTime > THAWING_PERIOD` because the result of `mulDivUp` will be greater than 100.

```
100 - FixedPointMathLib.mulDivUp((maturity - currentTime), 100, adapter.unlockTime())
```

While it is impossible to get an accurate progress on-chain for The Graph unlocks at this point, we can prevent the function from unexpectedly reverting by treating the unlockTime as `2*THAWING_PERIOD`. 



