### PR TITLE
Prevent successful withdrawals that burn unlock NFTs while transferring zero assets

### DIFF
--- a/src/tenderizer/Tenderizer.sol
+++ b/src/tenderizer/Tenderizer.sol
@@ -124,6 +124,7 @@ contract Tenderizer is TenderizerImmutableArgs, TenderizerEvents, TToken, Multic
 
         // withdraw assets to send to `receiver`
         amount = _withdraw(validator(), unlockID);
+        if (amount == 0) revert InsufficientAssets();
 
         // transfer assets to `receiver`
         ERC20(asset()).safeTransfer(receiver, amount);

--- a/test/tenderizer/Tenderizer.t.sol
+++ b/test/tenderizer/Tenderizer.t.sol
@@ -17,6 +17,7 @@ import { StdCheats } from "forge-std/StdCheats.sol";
 import { IERC20, IERC20Metadata } from "core/interfaces/IERC20.sol";
 import { Adapter, TenderizerHarness } from "test/tenderizer/Tenderizer.harness.sol";
 import { AdapterDelegateCall } from "core/adapters/Adapter.sol";
+import { Tenderizer as TenderizerContract } from "core/tenderizer/Tenderizer.sol";
 import { TenderizerEvents } from "core/tenderizer/TenderizerBase.sol";
 import { StaticCallFailed } from "core/utils/StaticCall.sol";
 import { TToken } from "core/tendertoken/TToken.sol";
@@ -296,6 +297,16 @@ contract TenderizerTest is TenderizerSetup, TenderizerEvents {
 
         vm.expectRevert(abi.encodeWithSelector(AdapterDelegateCall.AdapterDelegateCallFailed.selector, ERROR_MESSAGE));
         tenderizer.withdraw(account1, unlockID);
+    }
+
+    function test_Withdraw_RevertIfAdapterReturnsZeroAssets() public {
+        uint256 unlockID = 1;
+        vm.mockCall(unlocks, abi.encodeCall(Unlocks.useUnlock, (account1, unlockID)), "");
+        vm.mockCall(adapter, abi.encodeCall(Adapter.withdraw, (validator, unlockID)), abi.encode(0));
+
+        vm.prank(account1);
+        vm.expectRevert(TenderizerContract.InsufficientAssets.selector);
+        tenderizer.withdraw(account2, unlockID);
     }
 
     function test_Withdraw_RevertIfUseUnlockFails() public {


### PR DESCRIPTION
This patch makes `Tenderizer.withdraw()` revert when the adapter returns `0` assets.

Today, the withdraw path can complete successfully even when the adapter returns zero. That means the user's unlock NFT is consumed, the unlock state can be deleted, `Withdraw(..., 0, unlockID)` is emitted, and the user receives no underlying asset.

A successful withdrawal should probably withdraw something.

This is especially important for adapter integrations where upstream protocol state can change or return unexpected values. Reverting preserves the unlock NFT and all state, giving the protocol/team a chance to fix adapter accounting instead of finalizing a zero-asset redemption.

Related real-world failure mode:

- unlockID `42`
- withdraw emitted `assets = 0`
- GRT transfer amount `0`
- unlock NFT was burned

This patch does not fully fix the GRT/Horizon accounting issue, but it prevents the protocol from turning an accounting failure into an irreversible user-facing loss.

Validation:

- `git diff --check`
- `FOUNDRY_PROFILE=tenderizer forge test --match-contract TenderizerTest --match-test test_Withdraw_RevertIfAdapterReturnsZeroAssets`

Note: the focused test was run with a temporary local Foundry profile that limits compilation to `test/tenderizer`, because the current repository test tree has unrelated compile failures in existing GraphAdapter/fork tests under the default profile.
